### PR TITLE
Make crack_cipher outputs consistent for different ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Encrypt the text "Hello, World!" with the function `x -> 3x+4`:
 
 ```julia
 encrypt_affine("Hello, World!", 3, 4)
-# outputs
+# outputs "ZQLLU, SUDLN!"
 ```
 
 Notice that `encrypt_affine` turns everything upper-case, but retains symbols.
@@ -81,7 +81,7 @@ Crack the same text:
 
 ```julia
 crack_affine("ZQLLU, SUDLN!")
-# outputs ((3, 4), "hello, world!")
+# outputs ("hello, world!", (3, 4))
 ```
 
 You can provide `mult=` or `add=` options to `crack_affine`, if they are known,
@@ -118,7 +118,7 @@ It simply makes all specified changes, and leaves the rest of the string unchang
 Cracking a cipher:
 ```julia
 crack_monoalphabetic(str, chatty=0, rounds=10)
-# outputs (key, decrypted_string)
+# outputs (decrypted_string, key)
 ```
 
 The various optional arguments to `crack_monoalphabetic` are:

--- a/src/affine.jl
+++ b/src/affine.jl
@@ -61,5 +61,5 @@ function crack_affine(ciphertext; mult=0, add=-1)
 
 	sort!(decrypts, by=(x -> string_fitness(x[2])))
 
-	decrypts[end]
+	reverse(decrypts[end])
 end

--- a/src/monoalphabetic.jl
+++ b/src/monoalphabetic.jl
@@ -172,6 +172,6 @@ function crack_monoalphabetic(ciphertext; starting_key="",
     println("Best was $(total_best_key) at $(total_best_fitness)")
     println(total_best_decrypt)
   end
-  (key, decrypt_monoalphabetic(ciphertext, key))
+  (decrypt_monoalphabetic(ciphertext, key), key)
 end
 

--- a/test/affine.jl
+++ b/test/affine.jl
@@ -5,7 +5,7 @@ using Base.Test
 
 @test encrypt_affine("Hello, World!", 3, 4) == "ZQLLU, SUDLN!"
 @test decrypt_affine("ZQLLU, SUDLN!", 3, 4) == "hello, world!" 
-@test crack_affine("zqllu, sudln!") == ((3, 4), "hello, world!")
+@test crack_affine("zqllu, sudln!") == ("hello, world!", (3, 4))
 
 # Wikipedia examples
 
@@ -16,7 +16,7 @@ using Base.Test
 
 @test encrypt_affine("defend the east wall of the castle", 5, 7) == uppercase("wbgbuw yqb bhty nhkk zg yqb rhtykb")
 @test decrypt_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb", 5, 7) == "defendtheeastwallofthecastle"
-@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb") == ((5, 7), "defendtheeastwallofthecastle")
+@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb") == ("defendtheeastwallofthecastle", (5, 7))
 
-@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb", mult=5) == ((5, 7), "defendtheeastwallofthecastle")
-@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb", add=7) == ((5, 7), "defendtheeastwallofthecastle")
+@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb", mult=5) == ("defendtheeastwallofthecastle", (5, 7))
+@test crack_affine("wbgbuwyqbbhtynhkkzgyqbrhtykb", add=7) == ("defendtheeastwallofthecastle", (5, 7))

--- a/test/playfair.jl
+++ b/test/playfair.jl
@@ -12,6 +12,8 @@ using Base.Test
 @test (arr = ['P' 'L' 'A' 'Y' 'F'; 'I' 'R' 'E' 'X' 'M'; 'B' 'C' 'D' 'G' 'H'; 'K' 'N' 'O' 'Q' 'S'; 'T' 'U' 'V' 'W' 'Z']; 
 	   encrypt_playfair("Hello, World!", arr) == "DMYRANVQCRGE")
 
+@test encrypt_playfair("HELXLOWORLD", "PLAYFIREXM") == "DMYRANVQCRGE"
+
 @test encrypt_playfair("IJXYZA", "PLAYFIREXM", combined=('I', 'J')) == "RMRMFWYE"
 @test encrypt_playfair("IJXYZA", "PLAYFIREXM", combined=('X', 'Z')) == "BSGXEY"
 


### PR DESCRIPTION
Previously, different ciphers had crack_cipher outputting (key, decrypted) or (decrypted, key); standardise on (decrypted, key)