### PR TITLE
use specific version numbers for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - 0.6
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5
 Compat 0.9.5
 Iterators


### PR DESCRIPTION
since 0.4 is still supported according to REQUIRE,
but release is 0.5 at the moment and will be 0.6 soon